### PR TITLE
Change d2l-colors to ^

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.0",
     "vaadin-date-picker": "~1.2.3",
-    "d2l-colors": "~2.3.0"
+    "d2l-colors": "^2.4.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
d2l-colors 2.4.0 was just released and bumped pretty much everywhere else it seems, but the `~` here was causing issues. `^` to the rescue!