### PR TITLE
No need to bubble parse exception up

### DIFF
--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -223,7 +223,11 @@ A Date Picker for D2L Brightspace
 						return formatter.formatDate( date );
 					},
 					parseDate: function( dateString ) {
-						return parser.parseDate( dateString );
+					    try {
+					        return parser.parseDate( dateString );
+						} catch (exception) {
+					        return null;
+						}
 					}
 				};
 				var datePickerLocale = this._merge(datePicker.i18n, localeOverrides);

--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -223,10 +223,10 @@ A Date Picker for D2L Brightspace
 						return formatter.formatDate( date );
 					},
 					parseDate: function( dateString ) {
-					    try {
-					        return parser.parseDate( dateString );
+						try {
+							return parser.parseDate( dateString );
 						} catch (exception) {
-					        return null;
+							return null;
 						}
 					}
 				};


### PR DESCRIPTION
new parser was throwing unexpectedly, ideally we would want a try parse. When typing a date it is expected to have invalid date strings temporarily. It was logging and writing to console unnecessarily.