### PR TITLE
Date picker slot

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
-	"extends": "brightspace/polymer-config",
-	"globals" : {
-		"d2lIntl": true
-	}
+  "extends": "brightspace/polymer-config",
+  "globals": {
+    "d2lIntl": true,
+    "fastdom": false
+  }
 }

--- a/README.md
+++ b/README.md
@@ -43,5 +43,8 @@ The locale for the picker, for example, 'en', 'fr'...
 #### 'first-day-of-week'
 The first day of the week for the date picker, (0 = Sunday, 1 = Monday, 2 = Tuesday, 3 = Wednesday, 4 = Thursday, 5 = Friday, 6 = Saturday)
 
+#### 'custom-overlay-style'
+Allows the user to provide the `--vaadin-date-picker-overlay` mixin when set to true.
+
 ## Overriding the date format
 This repository uses https://github.com/BrightspaceUI/localize-behavior for formatting dates, if you need to override the date format, look there for instructions.

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "iron-a11y-keys": "^2.0.0",
     "iron-input": "^2.0.0",
     "polymer": "1.9 - 2",
-    "vaadin-date-picker": "^2.0.0"
+    "vaadin-date-picker": "1 - 2"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,6 @@
     }
   },
   "resolutions": {
-    "d2l-polymer-behaviors": "^1.0.0",
     "vaadin-date-picker": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "d2l-localize-behavior": "^1.1.0",
     "d2l-colors": "^3.1.2",
-    "d2l-fastdom-import": "Brightspace/d2l-fastdom-import#^1.0.0",
+    "d2l-fastdom-import": "Brightspace/fastdom-import#^1.0.0",
     "d2l-offscreen": "^3.0.1",
     "d2l-polymer-behaviors": "^1.0.0",
     "d2l-time-picker": "BrightspaceUI/time-picker#^1.0.0",
@@ -36,7 +36,7 @@
     "1.x": {
       "dependencies": {
         "polymer": "^1.9.1",
-        "vaadin-date-picker": "Brightspace/vaadin-date-picker#1.2.6"
+        "vaadin-date-picker": "Brightspace/vaadin-date-picker#^1.2.6"
       },
       "resolutions": {
         "iron-a11y-keys-behavior": "1 - 2",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "iron-a11y-keys": "^2.0.0",
     "iron-input": "^2.0.0",
     "polymer": "1.9 - 2",
-    "vaadin-date-picker": "1 - 2"
+    "vaadin-date-picker": "Brightspace/vaadin-date-picker#1 - 2"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "1.x": {
       "dependencies": {
         "polymer": "^1.9.1",
-        "vaadin-date-picker": "Brightspace/vaadin-date-picker#ad0856f74e46b2f6d9faf0a6cdfd3c90011104df"
+        "vaadin-date-picker": "Brightspace/vaadin-date-picker#1.2.6"
       },
       "resolutions": {
         "iron-a11y-keys-behavior": "1 - 2",

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "d2l-localize-behavior": "^1.1.0",
     "d2l-colors": "^3.1.2",
+    "d2l-fastdom-import": "Brightspace/d2l-fastdom-import#^1.0.0",
     "d2l-offscreen": "^3.0.1",
     "d2l-polymer-behaviors": "^1.0.0",
     "d2l-time-picker": "BrightspaceUI/time-picker#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -35,18 +35,11 @@
     "1.x": {
       "dependencies": {
         "polymer": "^1.9.1",
-        "vaadin-date-picker": "Brightspace/vaadin-date-picker#^1.2.5"
+        "vaadin-date-picker": "Brightspace/vaadin-date-picker#ad0856f74e46b2f6d9faf0a6cdfd3c90011104df"
       },
       "resolutions": {
-        "iron-a11y-announcer": "^2.0.0",
-        "iron-a11y-keys-behavior": "^2.0.0",
-        "iron-dropdown": "^2.0.0",
-        "iron-iconset-svg": "^2.0.0",
-        "iron-input": "^2.0.0",
-        "iron-media-query": "^2.0.0",
-        "iron-overlay-behavior": "^2.2.0",
-        "iron-resizable-behavior": "^2.0.0",
-        "iron-selector": "^2.0.0",
+        "iron-a11y-keys-behavior": "1 - 2",
+        "iron-selector": "1 - 2",
         "webcomponentsjs": "^0.7.24"
       }
     }

--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-fastdom-import/fastdom.html">
 <link rel="import" href="localize-behavior.html">
 
 <script>
@@ -74,8 +75,11 @@
 
 		attached: function() {
 			var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
+
 			for (var i = 0; i < buttons.length; i++) {
-				buttons[i].style.fontFamily = 'inherit';
+				fastdom.mutate(function() {
+					buttons[i].style.fontFamily = 'inherit';
+				});
 			}
 		},
 

--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -7,16 +7,13 @@
 	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 	window.D2L.PolymerBehaviors.DatePicker = window.D2L.PolymerBehaviors.DatePicker || {};
 
-	/** @polymerBehavior D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl */
+	/** @polymerBehavior D2L.PolymerBehaviors.DatePicker.DatePickerBehavior */
 	D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 		properties: {
 			_target: {
 				type: Object
 			},
 			_descriptionId: {
-				type: String
-			},
-			_labelId: {
 				type: String
 			},
 			placeholder: {
@@ -65,8 +62,8 @@
 		],
 
 		ready: function() {
-			this._labelId = D2L.Id.getUniqueId();
 			this._descriptionId = D2L.Id.getUniqueId();
+			this._handleValueChanged = this._handleValueChanged.bind(this);
 
 			if (this._isPolymer2()) {
 				this._setUpChangeEventListenerPolymer2();
@@ -76,16 +73,16 @@
 		attached: function() {
 			var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
 
-			for (var i = 0; i < buttons.length; i++) {
-				fastdom.mutate(function() {
+			fastdom.mutate(function() {
+				for (var i = 0; i < buttons.length; i++) {
 					buttons[i].style.fontFamily = 'inherit';
-				});
-			}
+				}
+			});
 		},
 
 		detached: function() {
-			if (this._changeListener) {
-				this.removeEventListener('value-changed', this._changeListener);
+			if (this._isPolymer2()) {
+				this.removeEventListener('value-changed', this._handleValueChanged);
 			}
 			this._changeListener = null;
 		},
@@ -93,8 +90,7 @@
 		_setUpChangeEventListenerPolymer2: function() {
 			// on-value-changed got removed for the Polymer2 version of vaadin-date-picker,
 			// so for Polymer2 we'll set our own event
-			this._changeListener = this._handleValueChanged.bind(this);
-			this.addEventListener('value-changed', this._changeListener);
+			this.addEventListener('value-changed', this._handleValueChanged);
 		},
 
 		_isPolymer2: function() {

--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -59,7 +59,6 @@
 		],
 
 		ready: function() {
-			this._target = this.$$('input');
 			this._labelId = D2L.Id.getUniqueId();
 			this._descriptionId = D2L.Id.getUniqueId();
 
@@ -117,7 +116,7 @@
 			}
 		},
 
-		_onEnter: function(e) {
+		onEnter: function(e) {
 			var datepicker = this.$$('vaadin-date-picker-light');
 			if (!datepicker.opened) {
 				// A better solution is to add a boolean to the 3rd party open function
@@ -129,7 +128,7 @@
 
 		},
 
-		_onUpDown: function(e) {
+		onUpDown: function(e) {
 			var datepicker = this.$$('vaadin-date-picker-light');
 			if (!datepicker.opened) {
 				e.detail.keyboardEvent.preventDefault();

--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -1,0 +1,204 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="localize-behavior.html">
+
+<script>
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.DatePicker = window.D2L.PolymerBehaviors.DatePicker || {};
+
+	/** @polymerBehavior D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl */
+	D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
+		properties: {
+			_target: {
+				type: Object
+			},
+			_descriptionId: {
+				type: String
+			},
+			_labelId: {
+				type: String
+			},
+			placeholder: {
+				type: String
+			},
+			min: {
+				type: String
+			},
+			max: {
+				type: String
+			},
+			label: {
+				type: String
+			},
+			hideLabel: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			},
+			description:{
+				type: String
+			},
+			locale: {
+				type: String,
+				value: 'en'
+			},
+			firstDayOfWeek: {
+				type: Number,
+				value: 0
+			},
+			value: {
+				type: String,
+				reflectToAttribute: true,
+				notify: true
+			}
+		},
+
+		observers: [
+			'_updateDatePickeri18n( locale, localize, firstDayOfWeek )',
+			'_localeChanged( locale )'
+		],
+
+		ready: function() {
+			this._target = this.$$('input');
+			this._labelId = D2L.Id.getUniqueId();
+			this._descriptionId = D2L.Id.getUniqueId();
+
+			if (this._isPolymer2()) {
+				this._setUpChangeEventListenerPolymer2();
+			}
+		},
+
+		attached: function() {
+			var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
+			for (var i = 0; i < buttons.length; i++) {
+				buttons[i].style.fontFamily = 'inherit';
+			}
+		},
+
+		detached: function() {
+			if (this._changeListener) {
+				this.removeEventListener('value-changed', this._changeListener);
+			}
+			this._changeListener = null;
+		},
+
+		_setUpChangeEventListenerPolymer2: function() {
+			// on-value-changed got removed for the Polymer2 version of vaadin-date-picker,
+			// so for Polymer2 we'll set our own event
+			this._changeListener = this._handleValueChanged.bind(this);
+			this.addEventListener('value-changed', this._changeListener);
+		},
+
+		_isPolymer2: function() {
+			return !!Polymer.Element;
+		},
+
+		_handleValueChangedPolymer1: function(e) {
+			// using the `value-changed` listener sometimes sends 2 events in the
+			// Polymer 1 vaadin-date-picker when in shadyDom, so this function listens to
+			// on-value-changed from the vaadin-date-picker (removed in Polymer 2)
+			if (this._isPolymer2()) {
+				return;
+			}
+			this._handleValueChanged(e);
+		},
+
+		_handleValueChanged: function(e) {
+			this.dispatchEvent(new CustomEvent('d2l-date-picker-value-changed', {
+				detail: e.detail,
+				bubbles: true
+			}));
+		},
+
+		_handleTap: function() {
+			var datepicker = this.$$('vaadin-date-picker-light');
+			if (!datepicker.opened) {
+				datepicker._focusOverlayOnOpen = true;
+			}
+		},
+
+		_onEnter: function(e) {
+			var datepicker = this.$$('vaadin-date-picker-light');
+			if (!datepicker.opened) {
+				// A better solution is to add a boolean to the 3rd party open function
+				datepicker._focusOverlayOnOpen = true;
+				datepicker.open();
+				e.detail.keyboardEvent.preventDefault();
+				e.detail.keyboardEvent.stopPropagation();
+			}
+
+		},
+
+		_onUpDown: function(e) {
+			var datepicker = this.$$('vaadin-date-picker-light');
+			if (!datepicker.opened) {
+				e.detail.keyboardEvent.preventDefault();
+				e.detail.keyboardEvent.stopPropagation();
+			}
+		},
+
+		_handleFocus: function() {
+			// in shady DOM the input's "focus" event does not bubble,
+			// so no need to fire it
+			if (!Polymer.Settings.useShadow) {
+				this.dispatchEvent(new CustomEvent(
+					'focus',
+					{ bubbles: true, composed: false }
+				));
+			}
+		},
+
+		_localeChanged: function(locale) {
+			this.language = locale;
+		},
+
+		_updateDatePickeri18n: function() {
+			var locale = d2lIntl.LocaleProvider(this.locale);
+
+			var datePicker = this.$$('vaadin-date-picker-light');
+			var localeOverrides = {
+				monthNames: locale.date.calendar.months.long,
+				weekdays: locale.date.calendar.days.long,
+				weekdaysShort: locale.date.calendar.days.short,
+				firstDayOfWeek: this.firstDayOfWeek ? this.firstDayOfWeek : locale.date.calendar.firstDayOfWeek,
+				today: this.localize('today'),
+				cancel: this.localize('cancel'),
+				formatDate: function(date) {
+					return this.formatDate(date);
+				}.bind(this),
+				parseDate: function(dateString) {
+					try {
+						return this.parseDate(dateString);
+					} catch (exception) {
+						return null;
+					}
+				}.bind(this)
+			};
+			var datePickerLocale = this._merge(datePicker.i18n, localeOverrides);
+			datePicker.i18n = {}; // reassign to have Polymer refresh
+			datePicker.i18n = datePickerLocale;
+		},
+
+		_merge: function(obj1, obj2) {
+			if (obj2 === undefined || obj2 === null || typeof(obj2) !== 'object') {
+				return obj1;
+			}
+			Object.keys(obj2).forEach(function(i) {
+				if (obj1.hasOwnProperty(i)) {
+					if (typeof(obj2[i]) === 'object' && typeof(obj1[i]) === 'object') {
+						this._merge(obj1[i], obj2[i]);
+					} else {
+						obj1[i] = obj2[i];
+					}
+				}
+			}.bind(this));
+			return obj1;
+		}
+	};
+
+	/** @polymerBehavior D2L.PolymerBehaviors.DatePicker.DatePickerBehavior */
+	D2L.PolymerBehaviors.DatePicker.DatePickerBehavior = [
+		D2L.PolymerBehaviors.DatePicker.LocalizeBehavior,
+		D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl
+	];
+</script>

--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -50,6 +50,11 @@
 				type: String,
 				reflectToAttribute: true,
 				notify: true
+			},
+			customOverlayStyle: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
 			}
 		},
 

--- a/d2l-date-picker-style-modules.html
+++ b/d2l-date-picker-style-modules.html
@@ -48,7 +48,9 @@
 	<template>
 		<style include="vaadin-date-picker-overlay-default-theme">
 			:host {
+				max-height: 355px;
 				@apply --vaadin-date-picker-overlay;
+				font-family: inherit;
 			}
 
 			[part~="overlay-header"] {

--- a/d2l-date-picker-style-modules.html
+++ b/d2l-date-picker-style-modules.html
@@ -5,6 +5,14 @@
 <dom-module id="d2l-vaadin-date-picker-polymer1-styles">
 	<template>
 		<style>
+			/* how does host work in a style module? */
+			:host(:not([custom-overlay-style])) vaadin-date-picker-light {
+				--vaadin-date-picker-overlay: {
+					font-family: inherit;
+					max-height: 355px;
+				};
+			}
+
 			vaadin-date-picker-light {
 				--primary-color: var(--d2l-color-celestine);
 				--light-primary-color: var(--d2l-color-celestine-plus-1);
@@ -13,10 +21,6 @@
 				--primary-text-color: var(--d2l-color-ferrite);
 				--secondary-text-color: var(--d2l-color-tungsten);
 
-				--vaadin-date-picker-overlay: {
-					font-family: inherit;
-					max-height: 355px;
-				};
 				--vaadin-date-picker-yearscroller: {
 					font-family: inherit;
 				};
@@ -44,8 +48,7 @@
 	<template>
 		<style include="vaadin-date-picker-overlay-default-theme">
 			:host {
-				font-family: inherit;
-				max-height: 355px;
+				@apply --vaadin-date-picker-overlay;
 			}
 
 			[part~="overlay-header"] {

--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -64,22 +64,24 @@ A Date Picker for D2L Brightspace
 			value="{{value}}"
 			on-value-changed="_handleValueChangedPolymer1"
 		>
-			<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="_onEnter"></iron-a11y-keys>
-			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
-			<!-- .input class needed for polymer 1 version of vaadin-date-picker-light -->
-			<iron-input class="input">
-				<input
-					on-tap="_handleTap"
-					placeholder="{{placeholder}}"
-					class="d2l-input"
-					type="text"
-					on-focus="_handleFocus"
-					aria-describedby$="[[_descriptionId]]"
-					aria-labelledby$="[[_labelId]]"
-					aria-invalid$="[[_computedAriaInvalid(invalid)]]"
-				>
-				<div id="[[_descriptionId]]" class="d2l-date-picker-description" >{{description}}</div>
-			</iron-input>
+			<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="onEnter"></iron-a11y-keys>
+			<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="onUpDown"></iron-a11y-keys>
+			<slot>
+				<!-- .input class needed for polymer 1 version of vaadin-date-picker-light -->
+				<iron-input class="input">
+					<input
+						on-tap="_handleTap"
+						placeholder="{{placeholder}}"
+						class="d2l-input"
+						type="text"
+						on-focus="_handleFocus"
+						aria-describedby$="[[_descriptionId]]"
+						aria-labelledby$="[[_labelId]]"
+						aria-invalid$="[[_computedAriaInvalid(invalid)]]"
+					>
+					<div id="[[_descriptionId]]" class="d2l-date-picker-description" >{{description}}</div>
+				</iron-input>
+			</slot>
 		</vaadin-date-picker-light>
 	</template>
 
@@ -99,8 +101,18 @@ A Date Picker for D2L Brightspace
 				}
 			},
 
+			ready: function() {
+				var input = this.$$('input');
+				if (input) {
+					this._target = this.$$('input');
+				}
+			},
+
 			focus: function() {
-				this.$$('input').focus();
+				var input = this.$$('input');
+				if (input) {
+					input.focus();
+				}
 			},
 
 			_computedAriaInvalid: function(invalid) {

--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -57,7 +57,7 @@ A Date Picker for D2L Brightspace
 			</style>
 		</custom-style>
 
-		<label id="[[_labelId]]">{{label}}</label>
+		<label>[[label]]</label>
 		<vaadin-date-picker-light
 			min="[[min]]"
 			max="[[max]]"
@@ -76,7 +76,7 @@ A Date Picker for D2L Brightspace
 						type="text"
 						on-focus="_handleFocus"
 						aria-describedby$="[[_descriptionId]]"
-						aria-labelledby$="[[_labelId]]"
+						aria-label$="[[label]]"
 						aria-invalid$="[[_computedAriaInvalid(invalid)]]"
 					>
 					<div id="[[_descriptionId]]" class="d2l-date-picker-description" >{{description}}</div>

--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-id.html">
 <link rel="import" href="../d2l-time-picker/d2l-time-picker.html">
+<link rel="import" href="../d2l-fastdom-import/fastdom.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-date-picker-behavior.html">
 <link rel="import" href="d2l-date-picker-style-modules.html">
@@ -111,7 +112,9 @@ A Date Picker for D2L Brightspace
 			focus: function() {
 				var input = this.$$('input');
 				if (input) {
-					input.focus();
+					fastdom.mutate(function() {
+						input.focus();
+					});
 				}
 			},
 

--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../d2l-polymer-behaviors/d2l-id.html">
 <link rel="import" href="../d2l-time-picker/d2l-time-picker.html">
 <link rel="import" href="localize-behavior.html">
+<link rel="import" href="d2l-date-picker-behavior.html">
 <link rel="import" href="d2l-date-picker-style-modules.html">
 
 <!--
@@ -20,7 +21,8 @@ A Date Picker for D2L Brightspace
 		<custom-style>
 			<style
 				is="custom-style"
-				include="d2l-input-styles d2l-offscreen-shared-styles d2l-vaadin-date-picker-polymer1-styles"
+				include="d2l-input-styles
+				d2l-offscreen-shared-styles d2l-vaadin-date-picker-polymer1-styles"
 			>
 				:host {
 					display: block;
@@ -83,56 +85,13 @@ A Date Picker for D2L Brightspace
 
 	<script>
 		Polymer({
-
 			is: 'd2l-date-picker',
 
 			behaviors: [
-				D2L.PolymerBehaviors.DatePicker.LocalizeBehavior
+				D2L.PolymerBehaviors.DatePicker.DatePickerBehavior
 			],
 
 			properties: {
-				_target: {
-					type: Object
-				},
-				_descriptionId: {
-					type: String
-				},
-				_labelId: {
-					type: String
-				},
-				placeholder: {
-					type: String
-				},
-				min: {
-					type: String
-				},
-				max: {
-					type: String
-				},
-				value: {
-					type: String,
-					reflectToAttribute: true,
-					notify: true
-				},
-				label: {
-					type: String
-				},
-				hideLabel: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
-				description:{
-					type: String
-				},
-				locale: {
-					type: String,
-					value: 'en'
-				},
-				firstDayOfWeek: {
-					type: Number,
-					value: 0
-				},
 				invalid: {
 					type: Boolean,
 					value: false,
@@ -140,150 +99,8 @@ A Date Picker for D2L Brightspace
 				}
 			},
 
-			observers: [
-				'_updateDatePickeri18n( locale, localize, firstDayOfWeek )',
-				'_localeChanged( locale )'
-			],
-
-			ready: function() {
-				this._target = this.$$('input');
-				this._labelId = D2L.Id.getUniqueId();
-				this._descriptionId = D2L.Id.getUniqueId();
-
-				if (this._isPolymer2()) {
-					this._setUpChangeEventListenerPolymer2();
-				}
-			},
-
-			attached: function() {
-				var buttons = document.getElementsByClassName('vaadin-date-picker-overlay paper-button-0');
-				for (var i = 0; i < buttons.length; i++) {
-					buttons[i].style.fontFamily = 'inherit';
-				}
-			},
-
-			detached: function() {
-				if (this._changeListener) {
-					this.removeEventListener('value-changed', this._changeListener);
-				}
-				this._changeListener = null;
-			},
-
-			_setUpChangeEventListenerPolymer2: function() {
-				// on-value-changed got removed for the Polymer2 version of vaadin-date-picker,
-				// so for Polymer2 we'll set our own event
-				this._changeListener = this._handleValueChanged.bind(this);
-				this.addEventListener('value-changed', this._changeListener);
-			},
-
-			_isPolymer2: function() {
-				return !!Polymer.Element;
-			},
-
-			_handleValueChangedPolymer1: function(e) {
-				// using the `value-changed` listener sometimes sends 2 events in the
-				// Polymer 1 vaadin-date-picker when in shadyDom, so this function listens to
-				// on-value-changed from the vaadin-date-picker (removed in Polymer 2)
-				if (this._isPolymer2()) {
-					return;
-				}
-				this._handleValueChanged(e);
-			},
-
-			_handleValueChanged: function(e) {
-				this.dispatchEvent(new CustomEvent('d2l-date-picker-value-changed', {
-					detail: e.detail,
-					bubbles: true
-				}));
-			},
-
-			_handleTap: function() {
-				var datepicker = this.$$('vaadin-date-picker-light');
-				if (!datepicker.opened) {
-					datepicker._focusOverlayOnOpen = true;
-				}
-			},
-
-			_onEnter: function(e) {
-				var datepicker = this.$$('vaadin-date-picker-light');
-				if (!datepicker.opened) {
-					// A better solution is to add a boolean to the 3rd party open function
-					datepicker._focusOverlayOnOpen = true;
-					datepicker.open();
-					e.detail.keyboardEvent.preventDefault();
-					e.detail.keyboardEvent.stopPropagation();
-				}
-
-			},
-
-			_onUpDown: function(e) {
-				var datepicker = this.$$('vaadin-date-picker-light');
-				if (!datepicker.opened) {
-					e.detail.keyboardEvent.preventDefault();
-					e.detail.keyboardEvent.stopPropagation();
-				}
-			},
-
 			focus: function() {
 				this.$$('input').focus();
-			},
-
-			_handleFocus: function() {
-				// in shady DOM the input's "focus" event does not bubble,
-				// so no need to fire it
-				if (!Polymer.Settings.useShadow) {
-					this.dispatchEvent(new CustomEvent(
-						'focus',
-						{ bubbles: true, composed: false }
-					));
-				}
-			},
-
-			_localeChanged: function(locale) {
-				this.language = locale;
-			},
-
-			_updateDatePickeri18n: function() {
-				var locale = d2lIntl.LocaleProvider(this.locale);
-
-				var datePicker = this.$$('vaadin-date-picker-light');
-				var localeOverrides = {
-					monthNames: locale.date.calendar.months.long,
-					weekdays: locale.date.calendar.days.long,
-					weekdaysShort: locale.date.calendar.days.short,
-					firstDayOfWeek: this.firstDayOfWeek ? this.firstDayOfWeek : locale.date.calendar.firstDayOfWeek,
-					today: this.localize('today'),
-					cancel: this.localize('cancel'),
-					formatDate: function(date) {
-						return this.formatDate(date);
-					}.bind(this),
-					parseDate: function(dateString) {
-						try {
-							return this.parseDate(dateString);
-						} catch (exception) {
-							return null;
-						}
-					}.bind(this)
-				};
-				var datePickerLocale = this._merge(datePicker.i18n, localeOverrides);
-				datePicker.i18n = {}; // reassign to have Polymer refresh
-				datePicker.i18n = datePickerLocale;
-			},
-
-			_merge: function(obj1, obj2) {
-				if (obj2 === undefined || obj2 === null || typeof(obj2) !== 'object') {
-					return obj1;
-				}
-				Object.keys(obj2).forEach(function(i) {
-					if (obj1.hasOwnProperty(i)) {
-						if (typeof(obj2[i]) === 'object' && typeof(obj1[i]) === 'object') {
-							this._merge(obj1[i], obj2[i]);
-						} else {
-							obj1[i] = obj2[i];
-						}
-					}
-				}.bind(this));
-				return obj1;
 			},
 
 			_computedAriaInvalid: function(invalid) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,13 +17,58 @@
     </custom-style>
   </head>
   <body>
-    <div class="vertical-section-container centered">
-      <h3>Basic d2l-date-picker demo</h3>
-      <demo-snippet>
-        <template>
-          <d2l-date-picker></d2l-date-picker>
-        </template>
-      </demo-snippet>
-    </div>
+	<dom-module id="d2l-date-picker-button-demo">
+		<template>
+			<style>
+				button {
+					width: 100%;
+				}
+			</style>
+			<d2l-date-picker value="{{value}}">
+				<iron-a11y-keys target="[[_target]]" keys="enter" on-keys-pressed="_onEnter"></iron-a11y-keys>
+				<iron-a11y-keys target="[[_target]]" keys="up down" on-keys-pressed="_onUpDown"></iron-a11y-keys>
+				<button>[[_getButtonText(value)]]</button>
+			</d2l-date-picker>
+		</template>
+		<script>
+			Polymer({
+				is: 'd2l-date-picker-button-demo',
+				properties: {
+					value: {
+						type: String,
+						value: null
+					},
+					_target: Object
+				},
+				ready: function() {
+					this._target = this.$$('button');
+				},
+				_getButtonText: function(value) {
+					return value || 'Click Me!';
+				},
+				_onEnter: function(e) {
+					this.$$('d2l-date-picker').onEnter(e);
+				},
+				_onUpDown: function(e) {
+					this.$$('d2l-date-picker').onUpDown(e);
+				}
+			});
+		</script>
+	</dom-module>
+	<div class="vertical-section-container centered">
+		<h3>Basic d2l-date-picker demo</h3>
+		<demo-snippet>
+			<template>
+				<d2l-date-picker></d2l-date-picker>
+			</template>
+		</demo-snippet>
+
+		<h3>d2l-date-picker with slotted content</h3>
+		<demo-snippet>
+			<template>
+				<d2l-date-picker-button-demo></d2l-date-picker-button-demo>
+			</template>
+		</demo-snippet>
+	</div>
   </body>
 </html>


### PR DESCRIPTION
This builds upon https://github.com/BrightspaceUI/date-picker/pull/30, adding the option for the user to slot something other that an input element into the date picker, it also gives an option for the user to style the overlay if needed and fixes up the dependencies so that polymer 1.x works for a component that consumes this (consuming the `vaadin-date-picker` from 2 different forks was breaking the bower resolutions)

Needed for: https://github.com/Brightspace/d2l-upcoming-assessments-ui/pull/113/files