### PR TITLE
fix localizing hyphenated locales in activity feed

### DIFF
--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -57,8 +57,7 @@
 		},
 
 		observers: [
-			'_updateDatePickeri18n( locale, localize, firstDayOfWeek )',
-			'_localeChanged( locale )'
+			'_updateDatePickeri18n( locale, localize, firstDayOfWeek )'
 		],
 
 		ready: function() {
@@ -150,10 +149,6 @@
 					{ bubbles: true, composed: false }
 				));
 			}
-		},
-
-		_localeChanged: function(locale) {
-			this.language = locale;
 		},
 
 		_updateDatePickeri18n: function() {

--- a/d2l-date-picker-behavior.html
+++ b/d2l-date-picker-behavior.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-fastdom-import/fastdom.html">
-<link rel="import" href="localize-behavior.html">
 
 <script>
 	window.D2L = window.D2L || {};
@@ -197,7 +196,6 @@
 
 	/** @polymerBehavior D2L.PolymerBehaviors.DatePicker.DatePickerBehavior */
 	D2L.PolymerBehaviors.DatePicker.DatePickerBehavior = [
-		D2L.PolymerBehaviors.DatePicker.LocalizeBehavior,
 		D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl
 	];
 </script>

--- a/d2l-date-picker.html
+++ b/d2l-date-picker.html
@@ -88,7 +88,8 @@ A Date Picker for D2L Brightspace
 			is: 'd2l-date-picker',
 
 			behaviors: [
-				D2L.PolymerBehaviors.DatePicker.DatePickerBehavior
+				D2L.PolymerBehaviors.DatePicker.DatePickerBehavior,
+				D2L.PolymerBehaviors.DatePicker.LocalizeBehavior
 			],
 
 			properties: {


### PR DESCRIPTION
This makes things like `en-us` localize properly in my hacked-up version of activity feed, hopefully it works with the normal one as well