### PR TITLE
US100352 - Lang terms DA and FI

### DIFF
--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -18,6 +18,10 @@
 								today: 'اليوم',
 								cancel: 'إلغاء'
 							},
+							'da': {
+								today: 'i dag',
+								cancel: 'annuller'
+							},
 							'en': {
 								today: 'today',
 								cancel: 'cancel'
@@ -25,6 +29,10 @@
 							'es': {
 								today: 'hoy',
 								cancel: 'cancelar'
+							},
+							'fi': {
+								today: 'tänään',
+								cancel: 'peruuta'
 							},
 							'fr': {
 								today: 'aujourd\'hui',

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,17 +10,17 @@
       "browsers": [
         {
           "browserName": "chrome",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "firefox",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {


### PR DESCRIPTION
Add danish and finnish translation terms.

DE (german) translations seem to be missing.