### PR TITLE
use d2l-inputs styles instead of timepicker's local copy

### DIFF
--- a/d2l-date-picker.js
+++ b/d2l-date-picker.js
@@ -14,7 +14,7 @@ import '@vaadin/vaadin-date-picker/vaadin-date-picker-light.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import 'd2l-polymer-behaviors/d2l-id.js';
-import 'd2l-time-picker/d2l-input-styles.js';
+import 'd2l-inputs/d2l-input-shared-styles.js';
 import 'fastdom/fastdom.js';
 import './d2l-date-picker-behavior.js';
 import './d2l-date-picker-style-modules.js';
@@ -65,7 +65,15 @@ Polymer({
 
 			<iron-input>
 				<slot>
-					<input on-tap="_handleTap" placeholder="{{placeholder}}" class="d2l-input" type="text" on-focus="_handleFocus" aria-describedby$="[[_descriptionId]]" aria-label$="[[label]]" aria-invalid$="[[_computedAriaInvalid(invalid)]]">
+					<input
+						on-tap="_handleTap"
+						placeholder="{{placeholder}}"
+						class="d2l-input"
+						type="text"
+						on-focus="_handleFocus"
+						aria-describedby$="[[_descriptionId]]"
+						aria-label$="[[label]]"
+						aria-invalid$="[[_computedAriaInvalid(invalid)]]">
 					<div id="[[_descriptionId]]" class="d2l-date-picker-description">{{description}}</div>
 				</slot>
 			</iron-input>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "d2l-time-picker": "BrightspaceUI/time-picker#semver:^2",
+    "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
     "fastdom": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "@webcomponents/webcomponentsjs": "^2.2.1",
     "async": "^1.5.2",
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.11.0",
+    "eslint": "^4.18.1",
     "eslint-config-brightspace": "^0.4.1",
-    "eslint-plugin-html": "^5.0.0",
+    "eslint-plugin-html": "^4.0.2",
     "lodash": "^3.10.1",
     "polymer-cli": "^1.9.4",
     "wct-browser-legacy": "^1.0.2"


### PR DESCRIPTION
Contributes to https://trello.com/c/ZU24VJjn/111-border-styling-missing-on-comment-textbox