### PR TITLE
Don't clear i18n

### DIFF
--- a/d2l-date-picker-behavior.js
+++ b/d2l-date-picker-behavior.js
@@ -148,7 +148,6 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 			}.bind(this)
 		};
 		var datePickerLocale = this._merge(datePicker.i18n, localeOverrides);
-		datePicker.i18n = {}; // reassign to have Polymer refresh
 		datePicker.i18n = datePickerLocale;
 	},
 


### PR DESCRIPTION
From what I can tell this causes issues in Polymer 2 and 3. 

The specific crash I'm seeing occurs here: https://github.com/vaadin/vaadin-date-picker/blob/master/src/vaadin-date-picker-overlay-content.html#L450

If `i18n` is cleared, then the `formatDate` function is null and this crashes.

I tried at the beginning of this function to manually set `this.locale` to `fr` and my date picker opens in French, so I'm assuming that this reassign issue no longer exists.