### PR TITLE
switching to use intl v3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "extends": "brightspace/polymer-3-config",
   "globals": {
-    "d2lIntl": true,
     "fastdom": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ The placeholder text for when the date is empty
 #### 'label'
 The label for the input field
 
-#### 'first-day-of-week'
-The first day of the week for the date picker, (0 = Sunday, 1 = Monday, 2 = Tuesday, 3 = Wednesday, 4 = Thursday, 5 = Friday, 6 = Saturday)
-
 #### 'custom-overlay-style'
 Allows the user to provide the `--vaadin-date-picker-overlay` mixin when set to true.
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ The placeholder text for when the date is empty
 #### 'label'
 The label for the input field
 
-#### 'locale'
-The locale for the picker, for example, 'en', 'fr'...
-
 #### 'first-day-of-week'
 The first day of the week for the date picker, (0 = Sunday, 1 = Monday, 2 = Tuesday, 3 = Wednesday, 4 = Thursday, 5 = Friday, 6 = Saturday)
 

--- a/d2l-date-picker-behavior.js
+++ b/d2l-date-picker-behavior.js
@@ -36,10 +36,6 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 		description:{
 			type: String
 		},
-		locale: {
-			type: String,
-			value: 'en'
-		},
 		firstDayOfWeek: {
 			type: Number,
 			value: 0
@@ -60,7 +56,7 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 	},
 
 	observers: [
-		'_updateDatePickeri18n( locale, localize, firstDayOfWeek )'
+		'_updateDatePickeri18n( localize, firstDayOfWeek )'
 	],
 
 	ready: function() {

--- a/d2l-date-picker-behavior.js
+++ b/d2l-date-picker-behavior.js
@@ -1,7 +1,7 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'fastdom/fastdom.js';
 import './localize-behavior.js';
-import d2lIntl from 'd2l-intl';
+import {getDateTimeDescriptor} from '@brightspace-ui/intl/lib/dateTime.js';
 import { useShadow } from '@polymer/polymer/lib/utils/settings.js';
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
@@ -128,14 +128,15 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 	},
 
 	_updateDatePickeri18n: function() {
-		var locale = d2lIntl.LocaleProvider(this.locale);
+
+		var descriptor = getDateTimeDescriptor();
 
 		var datePicker = this.$$('vaadin-date-picker-light');
 		var localeOverrides = {
-			monthNames: locale.date.calendar.months.long,
-			weekdays: locale.date.calendar.days.long,
-			weekdaysShort: locale.date.calendar.days.short,
-			firstDayOfWeek: this.firstDayOfWeek ? this.firstDayOfWeek : locale.date.calendar.firstDayOfWeek,
+			monthNames: descriptor.calendar.months.long,
+			weekdays: descriptor.calendar.days.long,
+			weekdaysShort: descriptor.calendar.days.short,
+			firstDayOfWeek: this.firstDayOfWeek ? this.firstDayOfWeek : descriptor.calendar.firstDayOfWeek,
 			today: this.localize('today'),
 			cancel: this.localize('cancel'),
 			formatDate: function(date) {

--- a/d2l-date-picker-behavior.js
+++ b/d2l-date-picker-behavior.js
@@ -36,10 +36,6 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 		description:{
 			type: String
 		},
-		firstDayOfWeek: {
-			type: Number,
-			value: 0
-		},
 		value: {
 			type: String,
 			reflectToAttribute: true,
@@ -56,7 +52,7 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 	},
 
 	observers: [
-		'_updateDatePickeri18n( localize, firstDayOfWeek )'
+		'_updateDatePickeri18n( localize )'
 	],
 
 	ready: function() {
@@ -132,7 +128,7 @@ D2L.PolymerBehaviors.DatePicker.DatePickerBehaviorImpl = {
 			monthNames: descriptor.calendar.months.long,
 			weekdays: descriptor.calendar.days.long,
 			weekdaysShort: descriptor.calendar.days.short,
-			firstDayOfWeek: this.firstDayOfWeek ? this.firstDayOfWeek : descriptor.calendar.firstDayOfWeek,
+			firstDayOfWeek: descriptor.calendar.firstDayOfWeek,
 			today: this.localize('today'),
 			cancel: this.localize('cancel'),
 			formatDate: function(date) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "version": "2.3.2",
   "dependencies": {
-    "@brightspace-ui/intl": "Brightspace/intl#v3",
+    "@brightspace-ui/intl": "^3",
     "@polymer/iron-a11y-keys": "^3.0.1",
     "@polymer/iron-dropdown": "^3.0.1",
     "@polymer/iron-input": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "version": "2.3.2",
   "dependencies": {
+    "@brightspace-ui/intl": "Brightspace/intl#v3",
     "@polymer/iron-a11y-keys": "^3.0.1",
     "@polymer/iron-dropdown": "^3.0.1",
     "@polymer/iron-input": "^3.0.1",


### PR DESCRIPTION
This adopts the breaking [changes to our Intl library](https://github.com/Brightspace/intl/pull/31). Won't be merged until Intl is published at its new location.