### PR TITLE
use Brightspace/vaadin-date-picker, which contains bug fix.

### DIFF
--- a/d2l-date-picker.js
+++ b/d2l-date-picker.js
@@ -9,7 +9,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-input/iron-input.js';
 import '@polymer/iron-a11y-keys/iron-a11y-keys.js';
 import '@polymer/iron-dropdown/iron-dropdown.js';
-import '@vaadin/vaadin-date-picker/vaadin-date-picker-light.js';
+import 'vaadin-date-picker/vaadin-date-picker-light.js';
 
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';

--- a/d2l-date-picker.js
+++ b/d2l-date-picker.js
@@ -9,7 +9,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-input/iron-input.js';
 import '@polymer/iron-a11y-keys/iron-a11y-keys.js';
 import '@polymer/iron-dropdown/iron-dropdown.js';
-import 'vaadin-date-picker/vaadin-date-picker-light.js';
+import '@vaadin/vaadin-date-picker/vaadin-date-picker-light.js';
 
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "@polymer/iron-dropdown": "^3.0.1",
     "@polymer/iron-input": "^3.0.1",
     "@polymer/polymer": "^3.1.0",
+    "@vaadin/vaadin-date-picker": "github:Brightspace/vaadin-date-picker#3.3",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
+    "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
-    "fastdom": "^1.0.8",
-    "vaadin-date-picker": "Brightspace/vaadin-date-picker#semver:^3"
+    "fastdom": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "@polymer/iron-dropdown": "^3.0.1",
     "@polymer/iron-input": "^3.0.1",
     "@polymer/polymer": "^3.1.0",
-    "@vaadin/vaadin-date-picker": "^3.3.2",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
-    "fastdom": "^1.0.8"
+    "fastdom": "^1.0.8",
+    "vaadin-date-picker": "Brightspace/vaadin-date-picker#semver:^3"
   }
 }


### PR DESCRIPTION
The bug is described here: https://github.com/Brightspace/vaadin-date-picker/pull/4
Now, we want to use the forked date-picker (with the bug fix) instead of vaadin directly.