### PR TITLE
BREAKING CHANGE: Upgrade to Lit 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "version": "3.1.0",
   "dependencies": {
-    "@brightspace-ui/core": "^2",
-    "@brightspace-ui/inputs": "^3",
+    "@brightspace-ui/core": "^3",
+    "@brightspace-ui/inputs": "^4",
     "@brightspace-ui/intl": "^3",
     "@brightspace-ui/localize-behavior": "^2",
     "@polymer/iron-a11y-keys": "^3.0.1",
@@ -43,5 +43,10 @@
     "@polymer/polymer": "^3.1.0",
     "@vaadin/vaadin-date-picker": "github:Brightspace/vaadin-date-picker#3.3",
     "fastdom": "^1.0.8"
-  }
+  },
+  "overrides": {
+		"lit-element": "^4",
+    "lit-html": "^3",
+    "lit": "^3"
+	}
 }


### PR DESCRIPTION
Since this component is **deprecated**, these changes are **temporary**. I strongly recommend `avoiding` this component and using https://github.com/BrightspaceUI/core/blob/main/components/inputs/input-date.js instead